### PR TITLE
IntelliJ run configurations

### DIFF
--- a/code_analysis/.gitignore
+++ b/code_analysis/.gitignore
@@ -13,7 +13,8 @@
 *.iml
 *.ipr
 *.iws
-.idea/
+.idea/*
+!.idea/runConfigurations
 
 # VS Code related
 .vscode/


### PR DESCRIPTION
It makes sense to share IntelliJ run configurations between developers.
Adder `.gitignore` rule, to include run configurations.

[More info](https://www.jetbrains.com/help/idea/run-debug-configuration.html)